### PR TITLE
Fix PHP deprecation notice

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -34,7 +34,6 @@ class Parser
             $configPath = __DIR__.'/.env';
         }
         $this->setConfigPath($configPath);
-        $this->contents = $this->loadFile($configPath);
     }
 
     /**


### PR DESCRIPTION
> PHP Deprecated:  Creation of dynamic property Psecio\SecureDotenv\Parser::$contents is deprecated in vendor\psecio\secure_dotenv\src\Parser.php on line 37
